### PR TITLE
Migrate from base64 to base64ct

### DIFF
--- a/ece/Cargo.toml
+++ b/ece/Cargo.toml
@@ -17,5 +17,5 @@ hkdf = "0.12.3"
 sha2 = "0.10.6"
 
 [dev-dependencies]
-base64 = "0.13.1"
+base64ct = { version = "1.5.3", features = ["alloc", "std"] }
 once_cell = "1.16.0"

--- a/ece/src/tests.rs
+++ b/ece/src/tests.rs
@@ -1,11 +1,11 @@
 use super::*;
-use base64;
+use base64ct::{Base64UrlUnpadded, Encoding};
 use once_cell::sync::Lazy;
 
 macro_rules! DECODE {
     ($e:expr) => {
         Lazy::new(|| {
-            let decoded = base64::decode_config($e, base64::URL_SAFE_NO_PAD).unwrap();
+            let decoded = Base64UrlUnpadded::decode_vec($e).unwrap();
             decoded.try_into().unwrap()
         })
     };

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-base64 = "0.13.1"
 axum = "0.6.1"
+base64ct = { version = "1.5.3", features = ["alloc", "std"] }
 hyper = { version = "0.14.23", features = ["full"] }
 hyper-rustls = "0.23.2"
 once_cell = "1.16.0"

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -5,6 +5,7 @@ use axum::{
     routing::{get, post},
     Json, Router, Server,
 };
+use base64ct::{Base64UrlUnpadded, Encoding};
 use hyper::{header, Body, Client, StatusCode};
 use hyper_rustls::HttpsConnectorBuilder;
 use once_cell::sync::Lazy;
@@ -17,11 +18,8 @@ use web_push_native::{
 
 /// VAPID key pair (keep private for real applications)
 static VAPID_PRIVATE: Lazy<ES256KeyPair> = Lazy::new(|| {
-    let bytes = base64::decode_config(
-        b"RS0WdYWWo1HajXg3NZR1olzCf31i-ZBGDkFyCs7j1jw",
-        base64::URL_SAFE,
-    )
-    .expect("this to be valid base64");
+    let bytes = Base64UrlUnpadded::decode_vec("RS0WdYWWo1HajXg3NZR1olzCf31i-ZBGDkFyCs7j1jw")
+        .expect("this to be valid base64");
     ES256KeyPair::from_bytes(&bytes).expect("this to be a valid private key")
 });
 
@@ -71,7 +69,7 @@ fn api_routes() -> Router {
         .route(
             "/vapid.json",
             get(|| async {
-                let encoded = base64::encode(
+                let encoded = Base64UrlUnpadded::encode_string(
                     &VAPID_PRIVATE
                         .key_pair()
                         .public_key()

--- a/web_push/Cargo.toml
+++ b/web_push/Cargo.toml
@@ -16,12 +16,12 @@ doctest = true
 
 [features]
 default = ["serde", "vapid"]
-serde = ["dep:serde", "dep:base64"]
-vapid = ["dep:jwt-simple", "dep:base64"]
+serde = ["dep:serde", "dep:base64ct"]
+vapid = ["dep:jwt-simple", "dep:base64ct"]
 
 [dependencies]
 aes-gcm = "0.10.1"
-base64 = { version = "0.13.1", optional = true }
+base64ct = { version = "1.5.3", features = ["alloc", "std"], optional = true }
 ece-native = { version = "0.1.0", path = "../ece" }
 hkdf = "0.12.3"
 http = "0.2.8"

--- a/web_push/src/lib.rs
+++ b/web_push/src/lib.rs
@@ -16,6 +16,7 @@
 //! directory on GitHub for a more fully-featured example.
 //!
 //! ```
+//! use base64ct::{Base64UrlUnpadded, Encoding};
 //! use web_push_native::{
 //!     jwt_simple::algorithms::ES256KeyPair, p256::PublicKey, Auth, Error, WebPushBuilder,
 //! };
@@ -32,11 +33,11 @@
 //! const VAPID: &str = "";
 //!
 //! async fn push(content: Vec<u8>) -> Result<http::Request<Vec<u8>>, Error> {
-//!     let key_pair = ES256KeyPair::from_bytes(&base64::decode_config(VAPID, base64::URL_SAFE)?)?;
+//!     let key_pair = ES256KeyPair::from_bytes(&Base64UrlUnpadded::decode_vec(VAPID)?)?;
 //!     let builder = WebPushBuilder::new(
 //!         ENDPOINT.parse()?,
-//!         PublicKey::from_sec1_bytes(&base64::decode_config(P256DH, base64::URL_SAFE)?)?,
-//!         Auth::clone_from_slice(&base64::decode_config(AUTH, base64::URL_SAFE)?),
+//!         PublicKey::from_sec1_bytes(&Base64UrlUnpadded::decode_vec(P256DH)?)?,
+//!         Auth::clone_from_slice(&Base64UrlUnpadded::decode_vec(AUTH)?),
 //!     )
 //!     .with_vapid(&key_pair, "mailto:john.doe@example.com");
 //!

--- a/web_push/src/tests.rs
+++ b/web_push/src/tests.rs
@@ -1,15 +1,16 @@
 use super::*;
+use base64ct::{Base64UrlUnpadded, Encoding};
 
 macro_rules! DECODE {
     ($e:expr) => {
         Lazy::new(|| {
-            let decoded = base64::decode_config($e, base64::URL_SAFE_NO_PAD).unwrap();
+            let decoded = Base64UrlUnpadded::decode_vec($e).unwrap();
             decoded.try_into().unwrap()
         })
     };
     ($extract:expr, $e:expr) => {
         Lazy::new(|| {
-            let decoded = base64::decode_config($e, base64::URL_SAFE_NO_PAD).unwrap();
+            let decoded = Base64UrlUnpadded::decode_vec($e).unwrap();
             Some($extract(&decoded).ok()).flatten().unwrap()
         })
     };

--- a/web_push/src/vapid.rs
+++ b/web_push/src/vapid.rs
@@ -1,4 +1,5 @@
 use super::{AddHeaders, Error, WebPushBuilder};
+use base64ct::{Base64UrlUnpadded, Encoding};
 use http::{header, Uri};
 use jwt_simple::{
     algorithms::{ECDSAP256KeyPairLike, ECDSAP256PublicKeyLike, ES256KeyPair, ES256PublicKey},
@@ -64,9 +65,8 @@ impl VapidSignature {
 
 impl From<VapidSignature> for http::HeaderValue {
     fn from(signature: VapidSignature) -> Self {
-        let encoded_public = base64::encode_config(
-            signature.public_key.public_key().to_bytes_uncompressed(),
-            base64::URL_SAFE_NO_PAD,
+        let encoded_public = Base64UrlUnpadded::encode_string(
+            &signature.public_key.public_key().to_bytes_uncompressed(),
         );
         let value = format!("vapid t={}, k={}", signature.token, encoded_public);
         Self::try_from(value).unwrap()


### PR DESCRIPTION
+ Some private keys are converted from and to base64
+ Large values are never converted from or to base64, so performance should not matter much
+ base64ct is maintained by the RustCrypto team
+ base64ct is a already transient dependency through jwt-simple