### PR TITLE
feat!: use concrete error type in `web_push`

### DIFF
--- a/web_push/Cargo.toml
+++ b/web_push/Cargo.toml
@@ -30,6 +30,7 @@ jwt-simple = { version = "0.11.4", optional = true }
 p256 = { version = "0.13.1", features = ["ecdh"] }
 serde = { version = "1.0.160", features = ["derive"], optional = true }
 sha2 = "0.10.6"
+thiserror = "1.0"
 
 [dev-dependencies]
 once_cell = "1.17.1"

--- a/web_push/src/error.rs
+++ b/web_push/src/error.rs
@@ -1,0 +1,22 @@
+use thiserror::Error;
+
+/// Result with this crate's error.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Error type for the crate.
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("could not encrypt using ECE")]
+    Encryption(#[from] ece_native::Error),
+
+    #[error("could not build request")]
+    Http(#[from] http::Error),
+
+    #[cfg(feature = "vapid")]
+    #[error("invalid subscription endpoint: {0}")]
+    InvalidSubscriptionEndpoint(&'static str),
+
+    #[cfg(feature = "vapid")]
+    #[error("VAPID signing failed")]
+    VapidSignature(#[from] jwt_simple::Error),
+}


### PR DESCRIPTION
`Box<dyn std::error::Error>` is not recommended for libraries as it makes it difficult for consumers to deal with errors. Using `thiserror` helps making a custom error type painless, and `thiserror` doesn't appear in the API at all.