### PR TITLE
Improve public error type and properly validate input length

### DIFF
--- a/web_push/src/lib.rs
+++ b/web_push/src/lib.rs
@@ -75,7 +75,7 @@ pub enum Error {
     /// Internal ECE error
     ECE(ece_native::Error),
     /// Internal error coming from an http auth provider
-    Extension(Box<dyn std::error::Error>),
+    Extension(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 
 impl std::error::Error for Error {}
@@ -149,7 +149,7 @@ impl WebPushBuilder {
 
 #[doc(hidden)]
 pub trait AddHeaders: Sized {
-    type Error: Into<Box<dyn std::error::Error>>;
+    type Error: Into<Box<dyn std::error::Error + Sync + Send + 'static>>;
 
     fn add_headers(
         this: &WebPushBuilder<Self>,

--- a/web_push/src/lib.rs
+++ b/web_push/src/lib.rs
@@ -171,7 +171,7 @@ impl<A: AddHeaders> WebPushBuilder<A> {
     pub fn build<T: Into<Vec<u8>>>(&self, body: T) -> Result<Request<Vec<u8>>, Error> {
         let body = body.into();
 
-        let payload = encrypt(body, &self.ua_public, &self.ua_auth).map_err(Error::ECE)?;
+        let payload = encrypt(body, &self.ua_public, &self.ua_auth)?;
         let builder = Request::builder()
             .uri(self.endpoint.clone())
             .method(http::method::Method::POST)
@@ -194,11 +194,11 @@ pub fn encrypt(
     message: Vec<u8>,
     ua_public: &p256::PublicKey,
     ua_auth: &Auth,
-) -> Result<Vec<u8>, ece_native::Error> {
+) -> Result<Vec<u8>, Error> {
     let mut salt = [0u8; 16];
     OsRng.fill_bytes(&mut salt);
     let as_secret = p256::SecretKey::random(&mut OsRng);
-    encrypt_predictably(salt, message, &as_secret, ua_public, ua_auth)
+    encrypt_predictably(salt, message, &as_secret, ua_public, ua_auth).map_err(Error::ECE)
 }
 
 fn encrypt_predictably(

--- a/web_push/src/lib.rs
+++ b/web_push/src/lib.rs
@@ -70,8 +70,11 @@ use std::time::Duration;
 /// Error type for HTTP push failure modes
 #[derive(Debug)]
 pub enum Error {
+    /// Key prefix of the encrypted message was too short
     PrefixLengthInvalid,
+    /// Internal ECE error
     ECE(ece_native::Error),
+    /// Internal error coming from an http auth provider
     Extension(Box<dyn std::error::Error>),
 }
 


### PR DESCRIPTION
This addresses some of the issues raised by in #4.

@ThinkChaos feel free to provide feedback on what you think about these changes. I know on public error variant still contains a `Box<dyn std::error::Error>`, but in my opinion this is the best way to deal with the opaque error type provided by `jwt_simple`, while also keeping the header/authentication provider system very generic.