### PR TITLE
Add lower-level VAPID header generation fn

### DIFF
--- a/web_push/src/lib.rs
+++ b/web_push/src/lib.rs
@@ -71,6 +71,9 @@ use p256::elliptic_curve::sec1::ToEncodedPoint;
 use sha2::Sha256;
 use std::time::Duration;
 
+#[cfg(feature = "vapid")]
+use crate::vapid::VapidSignature;
+
 /// Error type for HTTP push failure modes
 #[derive(Debug)]
 pub enum Error {
@@ -278,4 +281,16 @@ fn view_keyid(encrypted_message: &[u8]) -> Result<&[u8], ece_native::Error> {
     }
 
     Ok(&encrypted_message[21..21 + idlen])
+}
+
+/// Lower-level VAPID header generation used for HTTP push request
+#[cfg(feature = "vapid")]
+pub fn vapid_header<T: ToString>(
+    endpoint: &Uri,
+    valid_duration: Duration,
+    contact: T,
+    key: &jwt_simple::algorithms::ES256KeyPair,
+) -> Result<http::HeaderValue, jwt_simple::Error> {
+    let vapid = VapidSignature::sign(endpoint, valid_duration, contact, key)?;
+    Ok(http::HeaderValue::from(vapid))
 }

--- a/web_push/src/vapid.rs
+++ b/web_push/src/vapid.rs
@@ -36,7 +36,7 @@ impl<'a> AddHeaders for VapidAuthorization<'a> {
 }
 
 #[derive(Clone, Debug)]
-struct VapidSignature {
+pub struct VapidSignature {
     token: String,
     public_key: ES256PublicKey,
 }
@@ -44,7 +44,7 @@ struct VapidSignature {
 impl VapidSignature {
     /// Creates and signs a new [`VapidSignature`] which can be used
     /// as a HTTP header value.
-    fn sign<T: ToString>(
+    pub fn sign<T: ToString>(
         endpoint: &Uri,
         valid_duration: Duration,
         contact: T,


### PR DESCRIPTION
The library has currently 2 lower-level functions that can be used without the WebPushBuilder, for instance to use another library to actually send the requests, but it misses one lower-level function to generate VAPID header.

This PR adds that lower-level function