### PR TITLE
fix: cast nonce sequence number to u64 to prevent wasm32 panic

### DIFF
--- a/ece/src/lib.rs
+++ b/ece/src/lib.rs
@@ -133,7 +133,7 @@ pub fn encrypt<IKM: AsRef<[u8]>, KI: AsRef<[u8]>, R: Iterator<Item = Vec<u8>>>(
 
     let records = records.enumerate().map(|(n, record)| {
         let mut seq = [0u8; 12];
-        seq[4..].copy_from_slice(&n.to_be_bytes());
+        seq[4..].copy_from_slice(&(n as u64).to_be_bytes());
         let key = derive_key(salt, ikm.as_ref());
         let nonce = derive_nonce(salt, ikm.as_ref(), seq);
         (key, nonce, record)
@@ -213,7 +213,7 @@ pub fn decrypt<IKM: AsRef<[u8]>>(
         .enumerate()
         .map(|(n, record)| {
             let mut seq = [0u8; 12];
-            seq[4..].copy_from_slice(&n.to_be_bytes());
+            seq[4..].copy_from_slice(&(n as u64).to_be_bytes());
             let key = derive_key(salt, ikm.as_ref());
             let nonce = derive_nonce(salt, ikm.as_ref(), seq);
             (key, nonce, record)

--- a/ece/src/lib.rs
+++ b/ece/src/lib.rs
@@ -132,8 +132,9 @@ pub fn encrypt<IKM: AsRef<[u8]>, KI: AsRef<[u8]>, R: Iterator<Item = Vec<u8>>>(
     let header = generate_encryption_header(salt, encrypted_record_size, keyid.as_ref())?;
 
     let records = records.enumerate().map(|(n, record)| {
+        let n: u64 = n.try_into().expect("index must fit into u64");
         let mut seq = [0u8; 12];
-        seq[4..].copy_from_slice(&(n as u64).to_be_bytes());
+        seq[4..].copy_from_slice(&n.to_be_bytes());
         let key = derive_key(salt, ikm.as_ref());
         let nonce = derive_nonce(salt, ikm.as_ref(), seq);
         (key, nonce, record)
@@ -212,8 +213,9 @@ pub fn decrypt<IKM: AsRef<[u8]>>(
         )
         .enumerate()
         .map(|(n, record)| {
+            let n: u64 = n.try_into().expect("index must fit into u64");
             let mut seq = [0u8; 12];
-            seq[4..].copy_from_slice(&(n as u64).to_be_bytes());
+            seq[4..].copy_from_slice(&n.to_be_bytes());
             let key = derive_key(salt, ikm.as_ref());
             let nonce = derive_nonce(salt, ikm.as_ref(), seq);
             (key, nonce, record)


### PR DESCRIPTION
`encrypt` and `decrypt` in `ece/src/lib.rs` build a 12-byte nonce
sequence where `seq[4..]` is always 8 bytes (since `seq` is
`[0u8; 12]`), but `n.to_be_bytes()` depends on the platform's
`usize` width.

On 64-bit platforms this happens to work because `usize` is 8 bytes.
On wasm32, `usize` is 4 bytes, so `copy_from_slice` panics due to
the length mismatch (8 vs 4).

I hit this when using the crate in Cloudflare Workers (wasm32 target).

Casting `n` to `u64` ensures `to_be_bytes()` always returns 8 bytes,
matching the fixed-size slice on all platforms.